### PR TITLE
Integrate React Query for Data Fetching and Add FetchApi Utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@tanstack/react-query": "^5.76.1",
+        "@tanstack/react-query-devtools": "^5.76.1",
         "@tanstack/react-router": "^1.120.3",
         "@tanstack/react-router-devtools": "^1.120.3",
         "@tanstack/virtual-file-routes": "^1.115.0",
@@ -4432,6 +4434,59 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.76.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.76.0.tgz",
+      "integrity": "sha512-FN375hb8ctzfNAlex5gHI6+WDXTNpe0nbxp/d2YJtnP+IBM6OUm7zcaoCW6T63BawGOYZBbKC0iPvr41TteNVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.76.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.76.0.tgz",
+      "integrity": "sha512-1p92nqOBPYVqVDU0Ua5nzHenC6EGZNrLnB2OZphYw8CNA1exuvI97FVgIKON7Uug3uQqvH/QY8suUKpQo8qHNQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.76.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.76.1.tgz",
+      "integrity": "sha512-YxdLZVGN4QkT5YT1HKZQWiIlcgauIXEIsMOTSjvyD5wLYK8YVvKZUPAysMqossFJJfDpJW3pFn7WNZuPOqq+fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.76.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.76.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.76.1.tgz",
+      "integrity": "sha512-LFVWgk/VtXPkerNLfYIeuGHh0Aim/k9PFGA+JxLdRaUiroQ4j4eoEqBrUpQ1Pd/KXoG4AB9vVE/M6PUQ9vwxBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.76.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.76.1",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-router": {
@@ -15459,18 +15514,18 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.2.tgz",
-      "integrity": "sha512-ZSvGOXKGceizRQIZSz7TGJ0pS3QLlVY/9hwxVh17W3re67je1RKYzFHivZ/t0tubU78Vkyb9WnHPENSBCzbckg==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
-        "fdir": "^6.4.3",
+        "fdir": "^6.4.4",
         "picomatch": "^4.0.2",
         "postcss": "^8.5.3",
         "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.12"
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "postinstall": "msw init"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.76.1",
+    "@tanstack/react-query-devtools": "^5.76.1",
     "@tanstack/react-router": "^1.120.3",
     "@tanstack/react-router-devtools": "^1.120.3",
     "@tanstack/virtual-file-routes": "^1.115.0",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,7 @@
+import { queryClient } from '@Front/app/config/queryClient';
+import { Providers } from '@Front/app/providers/Providers/Providers';
 import { createRouter } from '@Front/app/routing/router';
 import { RouterProvider } from '@tanstack/react-router';
-import { StrictMode } from 'react';
 
 type AppProps = {
   basename?: string;
@@ -10,8 +11,8 @@ export const App = ({ basename }: AppProps) => {
   const router = createRouter({ basename });
 
   return (
-    <StrictMode>
+    <Providers queryClient={queryClient}>
       <RouterProvider router={router} />
-    </StrictMode>
+    </Providers>
   );
 };

--- a/src/app/appHTMLElement.tsx
+++ b/src/app/appHTMLElement.tsx
@@ -1,4 +1,5 @@
 import { App } from '@Front/app/App';
+import { StrictMode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
 // eslint-disable-next-line import/no-default-export
@@ -12,7 +13,11 @@ export default class AppHTMLElement extends HTMLElement {
   }
 
   connectedCallback() {
-    this.root.render(<App basename={this.getAttribute('basename') ?? ''} />);
+    this.root.render(
+      <StrictMode>
+        <App basename={this.getAttribute('basename') ?? ''} />
+      </StrictMode>,
+    );
   }
 
   disconnectedCallback() {

--- a/src/app/config/queryClient.ts
+++ b/src/app/config/queryClient.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({});

--- a/src/app/providers/Providers/Providers.tsx
+++ b/src/app/providers/Providers/Providers.tsx
@@ -1,0 +1,10 @@
+import { QueryProvider } from '@Front/app/providers/QueryProvider/QueryProvider';
+import type { ComponentProps, PropsWithChildren } from 'react';
+
+type ProvidersProps = {
+  queryClient: ComponentProps<typeof QueryProvider>['queryClient'];
+};
+
+export const Providers = ({ queryClient, children }: PropsWithChildren<ProvidersProps>) => {
+  return <QueryProvider queryClient={queryClient}>{children}</QueryProvider>;
+};

--- a/src/app/providers/QueryProvider/QueryProvider.tsx
+++ b/src/app/providers/QueryProvider/QueryProvider.tsx
@@ -1,0 +1,16 @@
+import { QueryClientProvider, type QueryClient } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import type { PropsWithChildren } from 'react';
+
+type QueryProviderProps = {
+  queryClient: QueryClient;
+};
+
+export const QueryProvider = ({ queryClient, children }: PropsWithChildren<QueryProviderProps>) => {
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+};

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,3 +1,10 @@
 interface ImportMetaEnv {
   readonly FRONT_MOCK_ENABLE: 'true' | 'false';
 }
+
+type JsonValue = JsonObject | JsonArray | string | number | boolean | null;
+type JsonArray = Array<JsonValue>;
+type JsonObject = {
+  [key: string]: JsonValue;
+};
+type Json = JsonObject | JsonArray;

--- a/src/shared/infrastructure/constant.ts
+++ b/src/shared/infrastructure/constant.ts
@@ -1,0 +1,22 @@
+export const METHODS = Object.freeze({
+  get: 'GET',
+  post: 'POST',
+  put: 'PUT',
+  patch: 'PATCH',
+  delete: 'DELETE',
+});
+
+export type MethodType = (typeof METHODS)[keyof typeof METHODS];
+
+export const HEADERS = Object.freeze({
+  contentType: 'content-type',
+});
+
+export type HeaderType = (typeof HEADERS)[keyof typeof HEADERS];
+
+export const MIME_TYPES = Object.freeze({
+  json: 'application/json',
+  text: 'plain/text',
+});
+
+export type MimeType = (typeof MIME_TYPES)[keyof typeof MIME_TYPES];

--- a/src/shared/infrastructure/fetchApi.ts
+++ b/src/shared/infrastructure/fetchApi.ts
@@ -1,0 +1,54 @@
+import { HEADERS, METHODS, MIME_TYPES, MethodType, MimeType } from './constant';
+
+type FetchApiProps = {
+  path: string;
+  method?: MethodType;
+  data?: Json;
+  headers?: HeadersInit;
+};
+
+export class FetchApiError extends Error {
+  constructor(
+    message: string,
+    public readonly code?: number,
+    public readonly contentType?: MimeType,
+  ) {
+    super(message);
+    this.name = 'FetchApiError';
+  }
+}
+
+export const fetchApi = async <T extends Json | string>({
+  path,
+  method = METHODS.get,
+  data,
+  headers = [],
+}: FetchApiProps): Promise<T> => {
+  const mergeHeaders = new Headers(headers);
+
+  if (data) {
+    mergeHeaders.append(HEADERS.contentType, MIME_TYPES.json);
+  }
+
+  const response = await fetch(path, {
+    method,
+    ...(data && { body: JSON.stringify(data) }),
+    headers: mergeHeaders,
+  });
+
+  const content = await response.text();
+
+  if (!response.ok) {
+    throw new FetchApiError(
+      content,
+      response.status,
+      (response.headers.get(HEADERS.contentType) as MimeType) ?? MIME_TYPES.text,
+    );
+  }
+
+  if ((response.headers.get(HEADERS.contentType) ?? '').includes('json')) {
+    return JSON.parse(content) as T;
+  }
+
+  return content as T;
+};

--- a/tests/shared/infrastructure/fetchApi.test.ts
+++ b/tests/shared/infrastructure/fetchApi.test.ts
@@ -1,0 +1,96 @@
+import { server } from '@Mocks/server';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { fetchApi, FetchApiError } from '@Front/shared/infrastructure/fetchApi';
+import { METHODS, MIME_TYPES, HEADERS } from '@Front/shared/infrastructure/constant';
+
+describe('fetchApi', () => {
+  const fetchMock = vi.fn();
+  window.fetch = fetchMock;
+
+  beforeAll(() => {
+    server.close();
+  });
+
+  it('should return JSON data on success', async () => {
+    const mockResponse = { message: 'Success' };
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify(mockResponse)),
+      headers: new Headers({ [HEADERS.contentType]: MIME_TYPES.json }),
+    });
+
+    const result = await fetchApi<{ message: string }>({
+      path: '/api/test',
+      method: METHODS.get,
+    });
+
+    expect(result).toStrictEqual(mockResponse);
+    expect(fetch).toHaveBeenCalledWith('/api/test', {
+      method: METHODS.get,
+      headers: new Headers(),
+    });
+  });
+
+  it('should throw an error on HTTP failure', async () => {
+    const mockError = 'Not Found';
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve(mockError),
+      headers: new Headers({ [HEADERS.contentType]: MIME_TYPES.text }),
+    });
+
+    await expect(fetchApi({ path: '/api/error', method: METHODS.get })).rejects.toThrowError(FetchApiError);
+
+    expect(fetch).toHaveBeenCalledWith('/api/error', {
+      method: METHODS.get,
+      headers: new Headers(),
+    });
+  });
+
+  it('should handle non-JSON responses', async () => {
+    const mockResponse = 'Plain text response';
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(mockResponse),
+      headers: new Headers({ [HEADERS.contentType]: MIME_TYPES.text }),
+    });
+
+    const result = await fetchApi<string>({
+      path: '/api/text',
+      method: METHODS.get,
+    });
+
+    expect(result).toBe(mockResponse);
+    expect(fetch).toHaveBeenCalledWith('/api/text', {
+      method: METHODS.get,
+      headers: new Headers(),
+    });
+  });
+
+  it('should add Content-Type header for POST requests with data', async () => {
+    const mockResponse = { message: 'Created' };
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify(mockResponse)),
+      headers: new Headers({ [HEADERS.contentType]: MIME_TYPES.json }),
+    });
+
+    const postData = { name: 'Test' };
+    const result = await fetchApi<{ message: string }>({
+      path: '/api/create',
+      method: METHODS.post,
+      data: postData,
+    });
+
+    expect(result).toStrictEqual(mockResponse);
+    expect(fetch).toHaveBeenCalledWith('/api/create', {
+      method: METHODS.post,
+      body: JSON.stringify(postData),
+      headers: expect.any(Headers),
+    });
+
+    const calledHeaders = fetchMock.mock.calls[0][1]?.headers as Headers;
+    expect(calledHeaders.get(HEADERS.contentType)).toBe(MIME_TYPES.json);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,8 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "types": [
-      "./src/react-app-env.d.ts",
-      "@rsbuild/core/types",
-      "vitest/globals",
-      "@testing-library/jest-dom/vitest"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "types": ["./src/react-app-env.d.ts", "@rsbuild/core/types", "vitest/globals", "@testing-library/jest-dom/vitest"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -28,13 +19,9 @@
     "baseUrl": ".",
     "paths": {
       "@Front/*": ["src/*"],
-      "@Mocks/*": ["mocks/*"],
+      "@Mocks/*": ["mocks/*"]
     }
   },
-  "include": [
-    "src",
-    "mocks",
-    "vitest.setup.ts"
-  ],
+  "include": ["src", "mocks", "vitest.setup.ts", "tests"],
   "exclude": ["node_modules"]
 }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -15,11 +15,12 @@ export default defineConfig(({ mode }) => {
       setupFiles: 'vitest.setup.ts',
       clearMocks: true,
       css: false,
-      reporters: ['default', 'junit'],
+      reporters: ['default', 'junit', 'vitest-sonar-reporter'],
       outputFile: {
         junit: 'junit-report.xml',
+        'vitest-sonar-reporter': 'sonar-report.xml',
       },
-      include: ['src/**/*.(spec|test|steps).[jt]s?(x)'],
+      include: ['tests/**/*.(spec|test).[jt]s?(x)'],
       poolOptions: {
         forks: {
           minForks: env.CI ? 1 : undefined,


### PR DESCRIPTION
**Type of Pull Request :**

- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue :**

Indicate here the number of the GitHub issue associated with this Pull Request.

**Context :**

This PR introduces React Query to manage data fetching and caching in the application. It also adds a generic `fetchApi` utility and related types/constants to streamline HTTP requests. The update improves maintainability, testability, and developer experience.

**Proposed Changes :**

- Added `@tanstack/react-query` and `@tanstack/react-query-devtools` as dependencies.
- Created a `queryClient` configuration and provider wrappers for React Query.
- Refactored the app to use the new `Providers` component for context setup.
- Implemented a generic `fetchApi` utility and supporting constants/types for API calls.
- Added comprehensive unit tests for the `fetchApi` utility.
- Updated TypeScript types and project configuration (e.g., `tsconfig.json`, `vitest.config.mts`) to support the new utilities and test location.
- Minor updates to strict mode handling and overall code structure.

**Checklist :**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information :**

- The `fetchApi` utility is designed for flexibility and robust error handling.
- React Query Devtools are enabled for local development.
- All new features are covered with automated tests.